### PR TITLE
Fix issue where login message would appear for logged in users

### DIFF
--- a/Classes/Controller/EventController.php
+++ b/Classes/Controller/EventController.php
@@ -249,11 +249,8 @@ class EventController extends AbstractController
 
         $events = $this->eventRepository->findAllBySubscriber($subscribers);
 
-        $isNotLoggedIn = $GLOBALS['TSFE']->fe_user->user['username'] == NULL;
-
         $this->view->assign('subscribers', $subscribers);
         $this->view->assign('events', $events);
-        $this->view->assign('isNotLoggedIn', $isNotLoggedIn);
     }
 
     /**

--- a/Classes/Controller/EventController.php
+++ b/Classes/Controller/EventController.php
@@ -249,8 +249,11 @@ class EventController extends AbstractController
 
         $events = $this->eventRepository->findAllBySubscriber($subscribers);
 
+        $isNotLoggedIn = $GLOBALS['TSFE']->fe_user->user['username'] == NULL;
+
         $this->view->assign('subscribers', $subscribers);
         $this->view->assign('events', $events);
+        $this->view->assign('isNotLoggedIn', $isNotLoggedIn);
     }
 
     /**

--- a/Resources/Private/Templates/Event/ListOwn.html
+++ b/Resources/Private/Templates/Event/ListOwn.html
@@ -16,6 +16,8 @@ Otherwise your changes will be overwritten the next time you save the extension 
 	{namespace se=Slub\SlubEvents\ViewHelpers}
 
 <div>
+
+<!-- Check if user is known by SLUB_Events -->
 <f:if condition="{subscribers}">
 	<f:then>
 	<ul>
@@ -50,9 +52,17 @@ Otherwise your changes will be overwritten the next time you save the extension 
 	</ul>
 	</f:then>
 	<f:else>
-	<div class="hint">
-		<p class="extrabox">Bitte melden Sie sich <a href="<f:uri.external uri="https://katalog.slub-dresden.de/pds?func=load-login&calling_system=primo&institute=SLUB&url=https://www.slub-dresden.de/"></f:uri.external><f:uri.page addQueryString="1"></f:uri.page>">zunächst in Ihrem Konto an</a>. Sie werden automatisch zu "<f:translate key="view_my_events" />" zurückgeleitet.</p>
-	</div>
+	<!-- Check if user is logged in -->
+	<f:if condition="{isNotLoggedIn}">
+		<f:then>
+			<div class="hint">
+				<p class="extrabox">Bitte melden Sie sich <a href="<f:uri.external uri="https://katalog.slub-dresden.de/pds?func=load-login&calling_system=primo&institute=SLUB&url=https://www.slub-dresden.de/"></f:uri.external><f:uri.page addQueryString="1"></f:uri.page>">zunächst in Ihrem Konto an</a>. Sie werden automatisch zu "<f:translate key="view_my_events" />" zurückgeleitet.</p>
+			</div>
+		</f:then>
+		<f:else>
+			<p>Sie sind zu keiner Veranstaltung angemeldet.</p>
+		</f:else>
+	</f:if>
 	</f:else>
 </f:if>
 

--- a/Resources/Private/Templates/Event/ListOwn.html
+++ b/Resources/Private/Templates/Event/ListOwn.html
@@ -53,14 +53,14 @@ Otherwise your changes will be overwritten the next time you save the extension 
 	</f:then>
 	<f:else>
 	<!-- Check if user is logged in -->
-	<f:if condition="{isNotLoggedIn}">
+	<f:security.ifAuthenticated>
 		<f:then>
+			<p>Sie sind zu keiner Veranstaltung angemeldet.</p>
+		</f:then>
+		<f:else>
 			<div class="hint">
 				<p class="extrabox">Bitte melden Sie sich <a href="<f:uri.external uri="https://katalog.slub-dresden.de/pds?func=load-login&calling_system=primo&institute=SLUB&url=https://www.slub-dresden.de/"></f:uri.external><f:uri.page addQueryString="1"></f:uri.page>">zunächst in Ihrem Konto an</a>. Sie werden automatisch zu "<f:translate key="view_my_events" />" zurückgeleitet.</p>
 			</div>
-		</f:then>
-		<f:else>
-			<p>Sie sind zu keiner Veranstaltung angemeldet.</p>
 		</f:else>
 	</f:if>
 	</f:else>


### PR DESCRIPTION
The problem was that users that are unknown by SLUB_Events would get a
login message even though they are logged in.

The check for {subscribers} only works if the user previously was
subscribed to any event. Only then he/she is in the database table
`tx_slubevents_domain_model_subscriber` and the first if-condition is
not null.

Therefore we have to do a two-step check to display the message to avoid
showing the hint to logged in users. They get the info that they are not
subscribed to any event yet instead.