### PR TITLE
Add possibility to choose categories for events to display only them

### DIFF
--- a/Classes/Controller/CategoryController.php
+++ b/Classes/Controller/CategoryController.php
@@ -113,13 +113,15 @@ class CategoryController extends AbstractController
                 $wibas = $this->eventRepository->findWibaByContact($this->settings['contactSelection'], $this->settings['consultationSelection'], true);
             }
             if ($this->settings['showEvent']) {
-                $events = $this->eventRepository->findEventByContact($this->settings['contactSelection'], 0);
+                $events = $this->eventRepository->findEventByContact($this->settings['contactSelection'], $this->settings['eventSelection']);
             }
             if ($this->settings['showConsultation'] && $this->settings['consultationSelection'] > 0) {
                 $consultation = $this->eventRepository->findWibaByContact($this->settings['contactSelection'], $this->settings['consultationSelection'], false);
             }
         }
 
+
+        print_r($this->settings);
 
         #if ($category != NULL) {
         #	$events = $this->eventRepository->findAllGbByCategory($category);

--- a/Classes/Controller/CategoryController.php
+++ b/Classes/Controller/CategoryController.php
@@ -120,9 +120,6 @@ class CategoryController extends AbstractController
             }
         }
 
-
-        print_r($this->settings);
-
         #if ($category != NULL) {
         #	$events = $this->eventRepository->findAllGbByCategory($category);
         #}

--- a/Classes/Domain/Repository/EventRepository.php
+++ b/Classes/Domain/Repository/EventRepository.php
@@ -113,7 +113,7 @@ namespace Slub\SlubEvents\Domain\Repository;
      *
      * @return array The found Event Objects
      */
-    public function findEventByContact($contact)
+    public function findEventByContact($contact, $category = null)
     {
         $query = $this->createQuery();
 
@@ -121,6 +121,9 @@ namespace Slub\SlubEvents\Domain\Repository;
         $constraints[] = $query->equals('contact', $contact);
         $constraints[] = $query->equals('genius_bar', 0);
         $constraints[] = $query->equals('cancelled', 0);
+        if ($category != null) {
+            $constraints[] = $query->in('categories.uid', explode(',', $category));
+        }
         $constraints[] = $query->greaterThan('max_subscriber', 'subscribers');
         $constraints[] = $query->greaterThan('start_date_time', strtotime('today'));
 

--- a/Classes/Domain/Repository/EventRepository.php
+++ b/Classes/Domain/Repository/EventRepository.php
@@ -73,7 +73,9 @@ namespace Slub\SlubEvents\Domain\Repository;
      * Finds all datasets by MM relation contact
      *
      * @param \Slub\SlubEvents\Domain\Model\Contact $contact
-     * @param \Slub\SlubEvents\Domain\Model\Category $category
+     * @param integer $category
+     * @param boolean $bExcludeCategory
+     *
      * @return array The found Event Objects
      */
     public function findWibaByContact($contact, $category = 0, $bExcludeCategory)
@@ -110,6 +112,7 @@ namespace Slub\SlubEvents\Domain\Repository;
      * Finds all datasets by MM relation contact
      *
      * @param \Slub\SlubEvents\Domain\Model\Contact $contact
+     * @param string $category
      *
      * @return array The found Event Objects
      */

--- a/Configuration/FlexForms/flexform_eventgeniusbar.xml
+++ b/Configuration/FlexForms/flexform_eventgeniusbar.xml
@@ -102,12 +102,40 @@
                             <label>
                                 LLL:EXT:slub_events/Resources/Private/Language/locallang_be.xlf:flexforms.showevents
                             </label>
+                            <onChange>reload</onChange>
                             <displayCond><![CDATA[FIELD:switchableControllerActions:=:Category->contactList;Category->list;Category->gbList]]></displayCond>
                             <config>
                                 <type>check</type>
                             </config>
                         </TCEforms>
                     </settings.showEvent>
+
+                    <settings.eventSelection>
+                        <TCEforms>
+                            <label>
+                                LLL:EXT:slub_events/Resources/Private/Language/locallang_be.xlf:flexforms.catsforevents
+                            </label>
+                            <displayCond><![CDATA[FIELD:settings.showEvent:REQ:true]]></displayCond>
+                            <config>
+                                <type>select</type>
+                                <renderMode>tree</renderMode>
+                                <treeConfig>
+                                    <parentField>parent</parentField>
+                                    <appearance>
+                                        <expandAll>TRUE</expandAll>
+                                        <showHeader>TRUE</showHeader>
+                                    </appearance>
+                                </treeConfig>
+
+                                <foreign_table>tx_slubevents_domain_model_category</foreign_table>
+                                <foreign_table_where>AND tx_slubevents_domain_model_category.parent = 0 AND (tx_slubevents_domain_model_category.sys_language_uid = 0 OR tx_slubevents_domain_model_category.l10n_parent = 0) ORDER BY tx_slubevents_domain_model_category.sorting DESC</foreign_table_where>
+                                <size>5</size>
+                                <autoSizeMax>30</autoSizeMax>
+                                <minitems>1</minitems>
+                                <maxitems>99</maxitems>
+                            </config>
+                        </TCEforms>
+                    </settings.eventSelection>
 
                     <settings.showConsultation>
                         <TCEforms>

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -154,6 +154,10 @@
 			<source>Consultations category</source>
 			<target>Sprechstunden Kategorie</target>
 		</trans-unit>
+		<trans-unit id="flexforms.catsforevents" approved="yes">
+			<source>Events categories</source>
+			<target>Veranstaltungs Kategorien</target>
+		</trans-unit>
 		<trans-unit id="persEvents" approved="yes">
 			<source>Events</source>
 			<target>Veranstaltungen</target>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -117,6 +117,9 @@
 		<trans-unit id="flexforms.catforconsultations">
 			<source>Consultations category</source>
 		</trans-unit>
+		<trans-unit id="flexforms.catsforevents">
+			<source>Events categories</source>
+		</trans-unit>
 		<trans-unit id="persEvents">
 			<source>Events</source>
 		</trans-unit>


### PR DESCRIPTION
Hidden events are classified by categories. To avoid showing them in public, you must have the possibility to choose the categories for the "Personenseite".