### PR TITLE
Changed empty string to array. If not, then will be the values concat…

### DIFF
--- a/Classes/Controller/EventController.php
+++ b/Classes/Controller/EventController.php
@@ -352,6 +352,8 @@ class EventController extends AbstractController
 
         // if no contacts selection in user settings present --> look for the root categories
         if (!is_array($searchParameter['contacts'])) {
+            $searchParameter['contacts'] = array();
+
             foreach ($contacts as $uid => $contact) {
                 $searchParameter['contacts'][$uid] = $contact->getUid();
             }


### PR DESCRIPTION
…enated.

The variable $searchParameter['contacts'] is an empty string. This code: " $searchParameter['contacts'][$uid] = $contact->getUid();" concatenate the integer values to a string.