### PR TITLE
Fix 39

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 Documentation-GENERATED-temp/
+.vscode

--- a/Resources/Private/Partials/Subscriber/FormFieldsGb.html
+++ b/Resources/Private/Partials/Subscriber/FormFieldsGb.html
@@ -25,7 +25,7 @@
 	<f:translate key="tx_slubevents_domain_model_subscriber.message"/>
   <span class="required">*</span>
 </label>
-<f:form.textarea class="{readonly}" required="required" property="message" cols="60" rows="8"/><br/>
+<f:form.textarea class="{readonly}" additionalAttributes="{required: 'required'}" property="message" cols="60" rows="8"/><br/>
 
 <f:form.hidden property="number" value="1"/>
 <f:form.hidden property="editcode" value="<se:format.editCode event='{event}' />"/>


### PR DESCRIPTION
The TextareaViewhelper knows the required attribute as of TYPO3 9.2:

[Feature: #82704 - Add readonly and required attributes to
TextareaViewHelper](https://docs.typo3.org/c/typo3/cms-core/10.2/en-us/Changelog/9.2/Feature-82704-AddReadonlyAndRequiredAttributesToTextareaViewHelper.html)

We still need the compatibilty with TYPO3 8.7 LTS and do not which to
provide our own TextareaViewHelper as before. That's why the required
attribute moved to additionalAttributes.

This fixes #39.