### PR TITLE
Feature/use template root paths

### DIFF
--- a/Classes/Controller/CategoryController.php
+++ b/Classes/Controller/CategoryController.php
@@ -87,7 +87,7 @@ class CategoryController extends AbstractController
 
         if (count($categories) == 0) {
             // there are no further child categories --> show events
-            $this->forward('gbList');
+            $this->forward('gbList', null, null, ['category' => $category]);
         } else {
             $this->view->assign('categories', $categories);
         }
@@ -152,13 +152,16 @@ class CategoryController extends AbstractController
     public function gbListAction(Category $category = null)
     {
         $events = [];
+        $parentcategory = null;
+
         if ($category != null) {
             $events = $this->eventRepository->findAllGbByCategory($category);
+            $parentcategory = $category->getParent()->current();
         }
 
         $this->view->assign('events', $events);
         $this->view->assign('category', $category);
-        $this->view->assign('parentcategory', $category->getParent()->current());
+        $this->view->assign('parentcategory', $parentcategory);
     }
 
     /**

--- a/Classes/Controller/SubscriberController.php
+++ b/Classes/Controller/SubscriberController.php
@@ -594,18 +594,10 @@ class SubscriberController extends AbstractController
             $emailViewHTML->assign('event', $event);
             $emailViewHTML->assign('subscriber', ['name' => '###Name wird automatisch ausgefüllt###']);
 
-            $extbaseFrameworkConfiguration = $this->configurationManager->getConfiguration(
-                \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK
-            );
-            $templateRootPath = GeneralUtility::getFileAbsFileName(
-                $extbaseFrameworkConfiguration['view']['templateRootPaths'][10]
-            );
-            $partialRootPath = GeneralUtility::getFileAbsFileName(
-                $extbaseFrameworkConfiguration['view']['partialRootPaths'][10]
-            );
+            $emailViewHTML->setTemplateRootPaths(EmailHelper::resolveTemplateRootPaths($this->configurationManager));
+            $emailViewHTML->setPartialRootPaths(EmailHelper::resolvePartialRootPaths($this->configurationManager));
 
-            $emailViewHTML->setTemplatePathAndFilename($templateRootPath . 'Email/' . 'OnlineSurvey.html');
-            $emailViewHTML->setPartialRootPaths([$partialRootPath]);
+            $emailViewHTML->setTemplate('Email/' . 'OnlineSurvey.html');
 
             $emailTextHTML = $emailViewHTML->render();
         }

--- a/Classes/Helper/EmailHelper.php
+++ b/Classes/Helper/EmailHelper.php
@@ -67,23 +67,10 @@ class EmailHelper
         $emailViewHTML->setFormat('html');
         $emailViewHTML->assignMultiple($variables);
 
-        if ($configurationManager) {
-            $extbaseFrameworkConfiguration = $configurationManager->getConfiguration(
-                ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK
-            );
-            $templateRootPath = GeneralUtility::getFileAbsFileName(
-                $extbaseFrameworkConfiguration['view']['templateRootPaths'][10]
-            );
-            $partialRootPath = GeneralUtility::getFileAbsFileName(
-                $extbaseFrameworkConfiguration['view']['partialRootPaths'][10]
-            );
-        } else {
-            $templateRootPath = PATH_site . 'typo3conf/ext/slub_events/Resources/Private/Backend/Templates/';
-            $partialRootPath = PATH_site . 'typo3conf/ext/slub_events/Resources/Private/Backend/Partials/';
-        }
+        $emailViewHTML->setTemplateRootPaths(self::resolveTemplateRootPaths($configurationManager));
+        $emailViewHTML->setPartialRootPaths(self::resolvePartialRootPaths($configurationManager));
 
-        $emailViewHTML->setTemplatePathAndFilename($templateRootPath . 'Email/' . $templateName . '.html');
-        $emailViewHTML->setPartialRootPaths([$partialRootPath]);
+        $emailViewHTML->setTemplate('Email/' . $templateName . '.html');
 
         /** @var $message \TYPO3\CMS\Core\Mail\MailMessage */
         $message = GeneralUtility::makeInstance('TYPO3\\CMS\\Core\\Mail\\MailMessage');
@@ -108,7 +95,10 @@ class EmailHelper
             $ics->setFormat('ics');
             $ics->assignMultiple($variables);
 
-            $ics->setTemplatePathAndFilename($templateRootPath . 'Email/' . $templateName . '.ics');
+            $ics->setTemplateRootPaths(self::resolveTemplateRootPaths($configurationManager));
+            $ics->setPartialRootPaths(self::resolvePartialRootPaths($configurationManager));
+
+            $ics->setTemplate('Email/' . $templateName . '.ics');
 
             // the total basename length must not be more than 60 characters --> see writeFileToTypo3tempDir()
             $eventIcsFile = PATH_site . 'typo3temp/tx_slubevents/' .
@@ -139,8 +129,10 @@ class EmailHelper
             $csv->setFormat('csv');
             $csv->assignMultiple($variables);
 
-            $csv->setTemplatePathAndFilename($templateRootPath . 'Email/' . $templateName . '.csv');
-            $csv->setPartialRootPaths([$partialRootPath]);
+            $csv->setTemplateRootPaths(self::resolveTemplateRootPaths($configurationManager));
+            $csv->setPartialRootPaths(self::resolvePartialRootPaths($configurationManager));
+
+            $csv->setTemplate('Email/' . $templateName . '.csv');
 
             $eventCsvFile = PATH_site . 'typo3temp/tx_slubevents/' .
                 substr(
@@ -205,5 +197,41 @@ class EmailHelper
         $text = strip_tags($text);
 
         return $text;
+    }
+
+    /**
+     * @param ConfigurationManagerInterface $configurationManager
+     * @return string[]
+     */
+    public static function resolveTemplateRootPaths($configurationManager = null)
+    {
+        if ($configurationManager) {
+            $extbaseFrameworkConfiguration = $configurationManager->getConfiguration(
+                ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK
+            );
+            $templateRootPaths = $extbaseFrameworkConfiguration['view']['templateRootPaths'];
+        } else {
+            $templateRootPaths = [PATH_site . 'typo3conf/ext/slub_events/Resources/Private/Backend/Templates/'];
+        }
+
+        return $templateRootPaths;
+    }
+
+    /**
+     * @param ConfigurationManagerInterface $configurationManager
+     * @return string[]
+     */
+    public static function resolvePartialRootPaths($configurationManager = null)
+    {
+        if ($configurationManager) {
+            $extbaseFrameworkConfiguration = $configurationManager->getConfiguration(
+                ConfigurationManagerInterface::CONFIGURATION_TYPE_FRAMEWORK
+            );
+            $partialRootPaths = $extbaseFrameworkConfiguration['view']['partialRootPaths'];
+        } else {
+            $partialRootPaths = [PATH_site . 'typo3conf/ext/slub_events/Resources/Private/Backend/Partials/'];
+        }
+
+        return $partialRootPaths;
     }
 }

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -10,9 +10,18 @@ page {
 plugin.tx_slubevents {
 
     view {
-        templateRootPaths.10 = {$plugin.tx_slubevents.view.templateRootPath}
-        partialRootPaths.10 = {$plugin.tx_slubevents.view.partialRootPath}
-        layoutRootPaths.10 = {$plugin.tx_slubevents.view.layoutRootPath}
+        templateRootPaths {
+            0 = EXT:slub_events/Resources/Private/Templates/
+            10 = {$plugin.tx_slubevents.view.templateRootPath}
+        }
+        partialRootPaths {
+            0 = EXT:slub_events/Resources/Private/Partials/
+            10 = {$plugin.tx_slubevents.view.partialRootPath}
+        }
+        layoutRootPaths {
+            0 = EXT:slub_events/Resources/Private/Layouts/
+            10 = {$plugin.tx_slubevents.view.layoutRootPath}
+        }
         widget.TYPO3\CMS\Fluid\ViewHelpers\Widget\PaginateViewHelper.templateRootPath = {$plugin.tx_slubevents.view.templateRootPath}
     }
 
@@ -66,9 +75,18 @@ plugin.tx_slubevents {
 module.tx_slubevents < plugin.tx_slubevents
 module.tx_slubevents {
     view {
-        templateRootPaths.10 = {$module.tx_slubevents.view.templateRootPath}
-        partialRootPaths.10 = {$module.tx_slubevents.view.partialRootPath}
-        layoutRootPaths.10 = {$module.tx_slubevents.view.layoutRootPath}
+        templateRootPaths {
+            10 = EXT:slub_events/Resources/Private/Backend/Templates/
+            20 = {$module.tx_slubevents.view.templateRootPath}
+        }
+        partialRootPaths {
+            10 = EXT:slub_events/Resources/Private/Backend/Partials/
+            20 = {$module.tx_slubevents.view.partialRootPath}
+        }
+        layoutRootPaths {
+            10 = EXT:slub_events/Resources/Private/Backend/Layouts/
+            20 = {$module.tx_slubevents.view.layoutRootPath}
+        }
         widget.TYPO3\CMS\Fluid\ViewHelpers\Widget\PaginateViewHelper.templateRootPath = {$plugin.tx_slubevents.view.templateRootPath}
     }
 

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -31,7 +31,7 @@ not enough subscribers where found before the subscription end. In all cases an
 ics-calendar invitation is appended to the mails.
 
 The templates are not yet all localized but are easily changeable by
-overwriting templateRootPath etc. as usual with extbase/fluid
+overwriting templateRootPaths etc. as usual with extbase/fluid
 extensions.
 
 Please use for your feedback the `Github project website


### PR DESCRIPTION
Just put everything related to the 'template root paths' topic into a separate branch, including bugfixes. Shouldn't influence existing installation if template paths were configured via TypoScript constants.