### PR TITLE
Default value is required with excludable fields

### DIFF
--- a/Configuration/TCA/tx_slubevents_domain_model_event.php
+++ b/Configuration/TCA/tx_slubevents_domain_model_event.php
@@ -294,6 +294,7 @@ return [
                     ],
                 ],
                 'enableRichtext' => true,
+                'default' => ''
             ],
         ],
         'description'              => [


### PR DESCRIPTION
The teaser field is not always available for editors as it is excludeable. If the field is not accessible, there is no value to be inserted in the database which causes an exception.