### PR TITLE
Fix language overlay of in categories genius bar

### DIFF
--- a/Classes/Domain/Repository/CategoryRepository.php
+++ b/Classes/Domain/Repository/CategoryRepository.php
@@ -54,7 +54,6 @@ class CategoryRepository extends Repository
         $query = $this->createQuery();
 
         // we have to ignore sys_language here
-        // --> https://forge.typo3.org/issues/37696
         $query->getQuerySettings()->setRespectSysLanguage(false);
 
         $constraints = [];
@@ -207,10 +206,6 @@ class CategoryRepository extends Repository
     private function findChildCategories($startCategory = 0)
     {
         $query = $this->createQuery();
-
-        // we have to ignore sys_language here
-        // --> https://forge.typo3.org/issues/37696
-        $query->getQuerySettings()->setRespectSysLanguage(false);
 
         $constraints = [];
 

--- a/Configuration/FlexForms/flexform_eventgeniusbar.xml
+++ b/Configuration/FlexForms/flexform_eventgeniusbar.xml
@@ -51,8 +51,9 @@
                                 <foreign_table>tx_slubevents_domain_model_category</foreign_table>
                                 <foreign_table_where>AND tx_slubevents_domain_model_category.genius_bar = 1 AND
                                     (tx_slubevents_domain_model_category.sys_language_uid = 0 OR
-                                    tx_slubevents_domain_model_category.l10n_parent = 0) ORDER BY
-                                    tx_slubevents_domain_model_category.sorting ASC
+                                    tx_slubevents_domain_model_category.l10n_parent = 0) AND
+                                    tx_slubevents_domain_model_category.hidden = 0
+                                    ORDER BY tx_slubevents_domain_model_category.sorting ASC
                                 </foreign_table_where>
                                 <minitems>1</minitems>
                                 <maxitems>1</maxitems>


### PR DESCRIPTION
Disabling the language handling in `CategoryRepository::findChildCategories()` can cause random language labels in genius bar list view. This was necessary in former days of  TYPO3 (I think ~6.2) but is not necessary or even wrong today.

The same call in `CategoryRepository::findAllByUids()` is still necessary!