### PR TITLE
Fix email name in cancellation mails to subscriber

### DIFF
--- a/Classes/Helper/EmailHelper.php
+++ b/Classes/Helper/EmailHelper.php
@@ -47,7 +47,7 @@ class EmailHelper
      * @param array                         $variables    variables to be passed to the Fluid view
      * @param ConfigurationManagerInterface $configurationManager
      *
-     * @return boolean TRUE on success, otherwise false
+     * @return boolean true on success, otherwise false
      */
     public static function sendTemplateEmail(
         array $recipient,

--- a/Classes/Task/CheckeventsTask.php
+++ b/Classes/Task/CheckeventsTask.php
@@ -182,29 +182,25 @@ class CheckeventsTask extends AbstractTask
                 // check if we have to cancel the event
                 if ($this->subscriberRepository->countAllByEvent($event) < $event->getMinSubscriber()) {
                     // --> ok, we have to cancel the event because not enough subscriber were found
-
+                    $out = true;
                     // email to all subscribers
                     foreach ($event->getSubscribers() as $subscriber) {
-                        $cronLog .= 'Absage an Teilnehmer: ' . $event->getTitle() . ': ' . strftime('%x %H:%M',
-                                $event->getStartDateTime()->getTimestamp()) . ' --> ' . $subscriber->getEmail() . "\n";
-                        $out = EmailHelper::sendTemplateEmail(
+                        $out = $out && EmailHelper::sendTemplateEmail(
                             [$subscriber->getEmail() => $subscriber->getName()],
                             [$event->getContact()->getEmail() => $event->getContact()->getName()],
                             'Absage der Veranstaltung: ' . $event->getTitle(),
-                            'CancellEvent',
+                            'CancellEventSubscriber',
                             [
                                 'event' => $event,
-                                'subscribers' => '',
+                                'subscriber' => $subscriber,
                                 'helper' => $helper,
                                 'attachIcs' => true,
                             ]
                         );
                     }
 
-                    $cronLog .= 'Absage an Veranstalter: ' . $event->getTitle() . ': ' . strftime('%x %H:%M',
-                            $event->getStartDateTime()->getTimestamp()) . ' --> ' . $event->getContact()->getEmail() . "\n";
                     // email to event owner
-                    $out = EmailHelper::sendTemplateEmail(
+                    $out = $out && EmailHelper::sendTemplateEmail(
                         [$event->getContact()->getEmail() => $event->getContact()->getName()],
                         [$this->senderEmailAddress => 'SLUB Veranstaltungen - noreply'],
                         'Absage der Veranstaltung: ' . $event->getTitle(),
@@ -225,8 +221,6 @@ class CheckeventsTask extends AbstractTask
                 } else {
                     // event takes place but subscription is not possible anymore...
                     // email to event owner
-                    $cronLog .= 'Anmeldefrist abgelaufen an Veranstalter: ' . $event->getTitle() . ': ' . strftime('%x %H:%M',
-                            $event->getStartDateTime()->getTimestamp()) . ' --> ' . $event->getContact()->getEmail() . "\n";
                     $out = EmailHelper::sendTemplateEmail(
                         [$event->getContact()->getEmail() => $event->getContact()->getName()],
                         [$this->senderEmailAddress => 'SLUB Veranstaltungen - noreply'],

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -383,7 +383,7 @@
 			</trans-unit>
 			<trans-unit id="tx_slubevents_domain_model_location" approved="yes">
 				<source><![CDATA[Location]]></source>
-				<target><![CDATA[Ort]]></target>
+				<target><![CDATA[Veranstaltungsort]]></target>
 			</trans-unit>
 			<trans-unit id="tx_slubevents_domain_model_subscriber" approved="yes">
 				<source><![CDATA[Subscriber Details]]></source>

--- a/Resources/Private/Templates/Email/CancellEventSubscriber.html
+++ b/Resources/Private/Templates/Email/CancellEventSubscriber.html
@@ -1,8 +1,5 @@
 {namespace se=Slub\SlubEvents\ViewHelpers}
-<p>
-	<f:translate key='text.salutation'/>
-	{event.contact.name},
-</p>
+<p>{f:translate(key: 'text.salutation')} {subscriber.name},</p>
 
 <p>leider müssen wir folgende Veranstaltung absagen, da die Mindestteilnehmerzahl nicht erreicht wurde:</p>
 
@@ -19,15 +16,7 @@
 	</f:then>
 </f:if>
 
-<f:if condition="{subscribers}">
-	<f:then>
-		<p><b>Teilnehmerliste</b><br/>
-			<f:render partial="Email/ListAll" arguments="{subscribers: subscribers}"/>
-		</p>
-	</f:then>
-</f:if>
-
-<p>Anmeldungen sind nicht mehr möglich. Die Teilnehmer wurden gleichzeitig über die Absage informiert.</p>
+<p>Anmeldungen sind nicht mehr möglich.</p>
 
 <p>
 	<f:translate key='text.closing'/>

--- a/Resources/Private/Templates/Email/CancellEventSubscriber.ics
+++ b/Resources/Private/Templates/Email/CancellEventSubscriber.ics
@@ -1,0 +1,43 @@
+BEGIN:VCALENDAR
+METHOD:CANCEL
+PRODID:-//CALENDAR SLUB//DE
+VERSION:2.0
+BEGIN:VTIMEZONE
+TZID:Europe/Berlin
+BEGIN:DAYLIGHT
+DTSTART:20130331T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+TZNAME:CEST
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+END:DAYLIGHT
+BEGIN:STANDARD
+DTSTART:20131027T030000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+TZNAME:CET
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+ORGANIZER;CN="{event.contact.name}":MAILTO:{event.contact.email}
+DESCRIPTION:{helper.description}
+SUMMARY:{event.title}
+UID:{event.uid}-event-slub-dresden
+<f:if condition="{helper.allDay} == 1"><f:then>
+DTSTART;VALUE=DATE:<f:format.date date="@{helper.start}" format="Ymd" />
+<f:if condition="{helper.end} == 1"><f:then>
+DTEND;VALUE=DATE:<f:format.date date="@{helper.end}" format="Ymd" />
+</f:then></f:if>
+X-MICROSOFT-CDO-ALLDAYEVENT</f:then><f:else>
+DTSTART:<f:format.date date="@{helper.start}" format="Ymd\THis" />
+DTEND:<f:format.date date="@{helper.end}" format="Ymd\THis" /></f:else></f:if>
+DTSTAMP:<f:format.date date="@{helper.now}" format="Ymd\THis" />
+LAST-MODIFIED:<f:format.date date="@{helper.now}" format="Ymd\THis" />
+SEQUENCE:0
+CLASS:PUBLIC
+LOCATION:{helper.locationics}
+TRANSP:OPAQUE
+STATUS:CANCELLED
+END:VEVENT
+END:VCALENDAR

--- a/Resources/Private/Templates/Email/DeadlineReached.html
+++ b/Resources/Private/Templates/Email/DeadlineReached.html
@@ -6,7 +6,7 @@
 
 <p>für folgende Veranstaltung ist die Anmeldefrist abgelaufen.</p>
 
-<p><b>{event.title}</b></p>
+<p><strong>{event.title}</strong></p>
 
 <p>
 	<se:format.oneLine htmlString="<f:render partial='Event/DateFromTo' arguments='{event : event}' />"/>
@@ -14,7 +14,7 @@
 
 <f:if condition="{helper.location}">
 	<f:then>
-		<p><b>Veranstaltungsort:</b><br/>{helper.location}</p>
+		<p><strong>{f:translate(key: 'tx_slubevents_domain_model_location')}:</strong><br/>{helper.location}</p>
 		<f:format.html parseFuncTSPath="">{event.location.description}</f:format.html>
 	</f:then>
 </f:if>

--- a/Resources/Private/Templates/Email/Invitation.html
+++ b/Resources/Private/Templates/Email/Invitation.html
@@ -4,7 +4,7 @@
 	{event.contact.name},
 </p>
 
-<p><b>{event.title}</b></p>
+<p><strong>{event.title}</strong></p>
 
 <p>
 	<se:format.oneLine htmlString="<f:render partial='Event/DateFromTo' arguments='{event : event}' />"/>
@@ -12,7 +12,7 @@
 
 <f:if condition="{helper.location}">
 	<f:then>
-		<p><b>Veranstaltungsort: </b><br/>{helper.location}</p>
+		<p><strong>{f:translate(key: 'tx_slubevents_domain_model_location')}:</strong><br/>{helper.location}</p>
 		<f:format.html>{event.location.description}</f:format.html>
 	</f:then>
 </f:if>

--- a/Resources/Private/Templates/Email/Maximumreached.html
+++ b/Resources/Private/Templates/Email/Maximumreached.html
@@ -4,7 +4,7 @@
 <p>die folgende Veranstaltung hat die maximale Teilnehmerzahl von {event.maxSubscriber} erreicht und ist jetzt
 	ausgebucht:</p>
 
-<p><b>{event.title}</b></p>
+<p><strong>{event.title}</strong></p>
 
 <p>
 	<se:format.oneLine htmlString="<f:render partial='Event/DateFromTo' arguments='{event : event}' />"/>
@@ -12,7 +12,7 @@
 
 <f:if condition="{helper.location}">
 	<f:then>
-		<p><b>Veranstaltungsort: </b><br/>{helper.location}</p>
+		<p><strong>{f:translate(key: 'tx_slubevents_domain_model_location')}:</strong><br/>{helper.location}</p>
 		<f:format.html>{event.location.description}</f:format.html>
 	</f:then>
 </f:if>
@@ -45,4 +45,3 @@
 <p>&nbsp;</p>
 
 <p>{f:translate(key: 'text.signature')}</p>
-

--- a/Resources/Private/Templates/Email/Minimumreachedagain.html
+++ b/Resources/Private/Templates/Email/Minimumreachedagain.html
@@ -4,7 +4,7 @@
 <p>die folgende Veranstaltung hat nur noch {subscriberCount} und liegt damit unter der minimalen Teilnehmerzahl von
 	{event.minSubscriber}:</p>
 
-<p><b>{event.title}</b></p>
+<p><strong>{event.title}</strong></p>
 
 <p>
 	<se:format.oneLine htmlString="<f:render partial='Event/DateFromTo' arguments='{event : event}' />"/>
@@ -12,7 +12,7 @@
 
 <f:if condition="{helper.location}">
 	<f:then>
-		<p><b>Veranstaltungsort: </b><br/>{helper.location}</p>
+		<p><strong>{f:translate(key: 'tx_slubevents_domain_model_location')}:</strong><br/>{helper.location}</p>
 		<f:format.html>{event.location.description}</f:format.html>
 	</f:then>
 </f:if>
@@ -45,4 +45,3 @@
 <p>&nbsp;</p>
 
 <p>{f:translate(key: 'text.signature')}</p>
-

--- a/Resources/Private/Templates/Email/Newsubscriber.html
+++ b/Resources/Private/Templates/Email/Newsubscriber.html
@@ -3,7 +3,7 @@
 
 <p>die folgende Veranstaltung wurde soeben von <b>{newsubscriber.name}</b> gebucht:</p>
 
-<p><b>{event.title}</b></p>
+<p><strong>{event.title}</strong></p>
 
 <p>
 	<se:format.oneLine htmlString="<f:render partial='Event/DateFromTo' arguments='{event : event}' />"/>
@@ -11,7 +11,7 @@
 
 <f:if condition="{helper.location}">
 	<f:then>
-		<p><b>Veranstaltungsort: </b><br/>{helper.location}</p>
+		<p><strong>{f:translate(key: 'tx_slubevents_domain_model_location')}:</strong><br/>{helper.location}</p>
 		<f:format.html>{event.location.description}</f:format.html>
 	</f:then>
 </f:if>
@@ -44,4 +44,3 @@
 <p>&nbsp;</p>
 
 <p>{f:translate(key: 'text.signature')}</p>
-

--- a/Resources/Private/Templates/Email/OnlineSurvey.html
+++ b/Resources/Private/Templates/Email/OnlineSurvey.html
@@ -6,7 +6,7 @@
 
 <p>Sie haben kürzlich an folgender Veranstaltung teilgenommen:</p>
 
-<p><b>{event.title}</b> <br/>
+<p><strong>{event.title}</strong> <br/>
 	<se:format.oneLine htmlString="<f:render partial='Event/DateFromTo' arguments='{event : event}' />"/>
 </p>
 
@@ -34,4 +34,3 @@
 <p>
 	<f:translate key='text.signature'/>
 </p>
-

--- a/Resources/Private/Templates/Email/Subscribe.html
+++ b/Resources/Private/Templates/Email/Subscribe.html
@@ -10,7 +10,7 @@
 
 <p>vielen Dank für Ihre Anmeldung zu folgender Veranstaltung:</p>
 
-<p><b>{event.title}</b></p>
+<p><strong>{event.title}</strong></p>
 
 <p>
 	<se:format.oneLine htmlString="<f:render partial='Event/DateFromTo' arguments='{event : event}' />"/>
@@ -18,7 +18,7 @@
 
 <f:if condition="{helper.location}">
 	<f:then>
-		<p><b>Veranstaltungsort: </b><br/>{helper.location}</p>
+		<p><strong>{f:translate(key: 'tx_slubevents_domain_model_location')}:</strong><br/>{helper.location}</p>
 		<f:format.html>{event.location.description}</f:format.html>
 	</f:then>
 </f:if>
@@ -79,4 +79,3 @@
 <p>&nbsp;</p>
 
 <p>{event.contact.name} <br/>{f:translate(key: 'text.signature')}</p>
-

--- a/Resources/Private/Templates/Email/Unsubscribe.html
+++ b/Resources/Private/Templates/Email/Unsubscribe.html
@@ -3,7 +3,7 @@
 
 <p>Sie haben sich erfolgreich von der folgenden Veranstaltung abgemeldet:</p>
 
-<p><b>{event.title}</b></p>
+<p><strong>{event.title}</strong></p>
 
 <p>
 	<se:format.oneLine htmlString="<f:render partial='Event/DateFromTo' arguments='{event : event}' />"/>
@@ -11,7 +11,7 @@
 
 <f:if condition="{helper.location}">
 	<f:then>
-		<p><b>Veranstaltungsort: </b><br/>{helper.location}</p>
+		<p><strong>{f:translate(key: 'tx_slubevents_domain_model_location')}:</strong><br/>{helper.location}</p>
 		<f:format.html>{event.location.description}</f:format.html>
 	</f:then>
 </f:if>
@@ -33,4 +33,3 @@
 <p>&nbsp;</p>
 
 <p>{event.contact.name} <br/>{f:translate(key: 'text.signature')}</p>
-


### PR DESCRIPTION
Up to now, the same email template has been used to inform subscriber and contact person about the cancellation. This is not possible. There must be an individual template per direction.