### PR TITLE
Feature to use content elements like in news extensions

### DIFF
--- a/Classes/Domain/Model/Event.php
+++ b/Classes/Domain/Model/Event.php
@@ -101,6 +101,12 @@ class Event extends AbstractEntity
     protected $description;
 
     /**
+     * @var \TYPO3\CMS\Extbase\Persistence\ObjectStorage<\Slub\SlubEvents\Domain\Model\TtContent>
+     * @TYPO3\CMS\Extbase\Annotation\ORM\Lazy
+     */
+    protected $contentElements;
+
+    /**
      * Minimum of Subscribers
      *
      * @var integer
@@ -230,6 +236,36 @@ class Event extends AbstractEntity
     protected $recurringEndDateTime;
 
     /**
+     * Event constructor.
+     */
+    public function __construct()
+    {
+        //Do not remove the next line: It would break the functionality
+        $this->initStorageObjects();
+    }
+
+    /**
+     * Initializes all Tx_Extbase_Persistence_ObjectStorage properties.
+     *
+     * @return void
+     */
+    protected function initStorageObjects()
+    {
+        /**
+         * Do not modify this method!
+         * It will be rewritten on each save in the extension builder
+         * You may modify the constructor of this class instead
+         */
+        $this->categories = new ObjectStorage();
+
+        $this->contentElements = new ObjectStorage();
+
+        $this->discipline = new ObjectStorage();
+
+        $this->subscribers = new ObjectStorage();
+    }
+
+    /**
      * Returns hidden
      *
      * @return boolean $hidden
@@ -310,31 +346,63 @@ class Event extends AbstractEntity
     }
 
     /**
-     * Event constructor.
+     * Get content elements
+     *
+     * @return \TYPO3\CMS\Extbase\Persistence\ObjectStorage
      */
-    public function __construct()
+    public function getContentElements()
     {
-        //Do not remove the next line: It would break the functionality
-        $this->initStorageObjects();
+        return $this->contentElements;
     }
 
     /**
-     * Initializes all Tx_Extbase_Persistence_ObjectStorage properties.
+     * Set content element list
      *
-     * @return void
+     * @param \TYPO3\CMS\Extbase\Persistence\ObjectStorage $contentElements content elements
      */
-    protected function initStorageObjects()
+    public function setContentElements($contentElements)
     {
-        /**
-         * Do not modify this method!
-         * It will be rewritten on each save in the extension builder
-         * You may modify the constructor of this class instead
-         */
-        $this->categories = new ObjectStorage();
+        $this->contentElements = $contentElements;
+    }
 
-        $this->discipline = new ObjectStorage();
+    /**
+     * Get id list of content elements
+     *
+     * @return string
+     */
+    public function getContentElementIdList()
+    {
+        return $this->getIdOfContentElements();
+    }
 
-        $this->subscribers = new ObjectStorage();
+    /**
+     * Get translated id list of content elements
+     *
+     * @return string
+     */
+    public function getTranslatedContentElementIdList()
+    {
+        return $this->getIdOfContentElements(false);
+    }
+
+    /**
+     * Collect id list
+     *
+     * @param bool $original
+     * @return string
+     */
+    protected function getIdOfContentElements($original = true)
+    {
+        $idList = [];
+        $contentElements = $this->getContentElements();
+        if ($contentElements) {
+            foreach ($this->getContentElements() as $contentElement) {
+                if ($contentElement->getColPos() >= 0) {
+                    $idList[] = $original ? $contentElement->getUid() : $contentElement->_getProperty('_localizedUid');
+                }
+            }
+        }
+        return implode(',', $idList);
     }
 
     /**

--- a/Classes/Domain/Model/Event.php
+++ b/Classes/Domain/Model/Event.php
@@ -107,23 +107,31 @@ class Event extends AbstractEntity
     protected $contentElements;
 
     /**
+     * Fal media items
+     *
+     * @var \TYPO3\CMS\Extbase\Domain\Model\FileReference
+     */
+    protected $image;
+
+
+    /**
      * Minimum of Subscribers
      *
-     * @var integer
+     * @var int
      */
     protected $minSubscriber = 0;
 
     /**
      * Maximum of Subscribers
      *
-     * @var integer
+     * @var int
      */
     protected $maxSubscriber = 0;
 
     /**
      * Maximum amount of Persons per Subscription
      *
-     * @var integer
+     * @var int
      */
     protected $maxNumber = 0;
 
@@ -131,7 +139,7 @@ class Event extends AbstractEntity
      * Target Audience
      *
      * @Extbase\Validate("NotEmpty")
-     * @var integer
+     * @var int
      */
     protected $audience = 0;
 
@@ -403,6 +411,26 @@ class Event extends AbstractEntity
             }
         }
         return implode(',', $idList);
+    }
+
+    /**
+     * Returns the image
+     *
+     * @return \TYPO3\CMS\Extbase\Domain\Model\FileReference $image
+     */
+    public function getImage()
+    {
+        return $this->image;
+    }
+
+    /**
+     * Sets the image
+     *
+     * @param \TYPO3\CMS\Extbase\Domain\Model\FileReference $image
+     */
+    public function setImage($image)
+    {
+        $this->image = $image;
     }
 
     /**

--- a/Classes/Domain/Model/TtContent.php
+++ b/Classes/Domain/Model/TtContent.php
@@ -1,0 +1,524 @@
+<?php
+namespace Slub\SlubEvents\Domain\Model;
+
+/**
+ * This file is taken from the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+/**
+ * Model of tt_content
+ */
+class TtContent extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
+{
+
+    /**
+     * @var \DateTime
+     */
+    protected $crdate;
+
+    /**
+     * @var \DateTime
+     */
+    protected $tstamp;
+
+    /**
+     * @var string
+     */
+    protected $CType;
+
+    /**
+     * @var string
+     */
+    protected $header;
+
+    /**
+     * @var string
+     */
+    protected $headerPosition;
+
+    /**
+     * @var string
+     */
+    protected $bodytext;
+
+    /**
+     * @var int
+     */
+    protected $colPos;
+
+    /**
+     * @var string
+     */
+    protected $image;
+
+    /**
+     * @var int
+     */
+    protected $imagewidth;
+
+    /**
+     * @var int
+     */
+    protected $imageorient;
+
+    /**
+     * @var string
+     */
+    protected $imagecaption;
+
+    /**
+     * @var int
+     */
+    protected $imagecols;
+
+    /**
+     * @var int
+     */
+    protected $imageborder;
+
+    /**
+     * @var string
+     */
+    protected $media;
+
+    /**
+     * @var string
+     */
+    protected $layout;
+
+    /**
+     * @var int
+     */
+    protected $cols;
+
+    /**
+     * @var string
+     */
+    protected $subheader;
+
+    /**
+     * @var string
+     */
+    protected $headerLink;
+
+    /**
+     * @var string
+     */
+    protected $imageLink;
+
+    /**
+     * @var string
+     */
+    protected $imageZoom;
+
+    /**
+     * @var string
+     */
+    protected $altText;
+
+    /**
+     * @var string
+     */
+    protected $titleText;
+
+    /**
+     * @var string
+     */
+    protected $headerLayout;
+
+    /**
+     * @var string
+     */
+    protected $listType;
+
+    /**
+     * @return \DateTime
+     */
+    public function getCrdate()
+    {
+        return $this->crdate;
+    }
+
+    /**
+     * @param \DateTime $crdate
+     */
+    public function setCrdate($crdate)
+    {
+        $this->crdate = $crdate;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getTstamp()
+    {
+        return $this->tstamp;
+    }
+
+    /**
+     * @param \DateTime $tstamp
+     */
+    public function setTstamp($tstamp)
+    {
+        $this->tstamp = $tstamp;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCType()
+    {
+        return $this->CType;
+    }
+
+    /**
+     * @param $ctype
+     */
+    public function setCType($ctype)
+    {
+        $this->CType = $ctype;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHeader()
+    {
+        return $this->header;
+    }
+
+    /**
+     * @param $header
+     */
+    public function setHeader($header)
+    {
+        $this->header = $header;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHeaderPosition()
+    {
+        return $this->headerPosition;
+    }
+
+    /**
+     * @param $headerPosition
+     */
+    public function setHeaderPosition($headerPosition)
+    {
+        $this->headerPosition = $headerPosition;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBodytext()
+    {
+        return $this->bodytext;
+    }
+
+    /**
+     * @param $bodytext
+     */
+    public function setBodytext($bodytext)
+    {
+        $this->bodytext = $bodytext;
+    }
+
+    /**
+     * Get the colpos
+     *
+     * @return int
+     */
+    public function getColPos()
+    {
+        return (int)$this->colPos;
+    }
+
+    /**
+     * Set colpos
+     *
+     * @param int $colPos
+     */
+    public function setColPos($colPos)
+    {
+        $this->colPos = $colPos;
+    }
+
+    /**
+     * @return string
+     */
+    public function getImage()
+    {
+        return $this->image;
+    }
+
+    /**
+     * @param $image
+     */
+    public function setImage($image)
+    {
+        $this->image = $image;
+    }
+
+    /**
+     * @return int
+     */
+    public function getImagewidth()
+    {
+        return $this->imagewidth;
+    }
+
+    /**
+     * @param $imagewidth
+     */
+    public function setImagewidth($imagewidth)
+    {
+        $this->imagewidth = $imagewidth;
+    }
+
+    /**
+     * @return int
+     */
+    public function getImageorient()
+    {
+        return $this->imageorient;
+    }
+
+    /**
+     * @param $imageorient
+     */
+    public function setImageorient($imageorient)
+    {
+        $this->imageorient = $imageorient;
+    }
+
+    /**
+     * @return string
+     */
+    public function getImagecaption()
+    {
+        return $this->imagecaption;
+    }
+
+    /**
+     * @param $imagecaption
+     */
+    public function setImagecaption($imagecaption)
+    {
+        $this->imagecaption = $imagecaption;
+    }
+
+    /**
+     * @return int
+     */
+    public function getImagecols()
+    {
+        return $this->imagecols;
+    }
+
+    /**
+     * @param $imagecols
+     */
+    public function setImagecols($imagecols)
+    {
+        $this->imagecols = $imagecols;
+    }
+
+    /**
+     * @return int
+     */
+    public function getImageborder()
+    {
+        return $this->imageborder;
+    }
+
+    /**
+     * @param $imageborder
+     */
+    public function setImageborder($imageborder)
+    {
+        $this->imageborder = $imageborder;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMedia()
+    {
+        return $this->media;
+    }
+
+    /**
+     * @param $media
+     */
+    public function setMedia($media)
+    {
+        $this->media = $media;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLayout()
+    {
+        return $this->layout;
+    }
+
+    /**
+     * @param $layout
+     */
+    public function setLayout($layout)
+    {
+        $this->layout = $layout;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCols()
+    {
+        return $this->cols;
+    }
+
+    /**
+     * @param $cols
+     */
+    public function setCols($cols)
+    {
+        $this->cols = $cols;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSubheader()
+    {
+        return $this->subheader;
+    }
+
+    /**
+     * @param $subheader
+     */
+    public function setSubheader($subheader)
+    {
+        $this->subheader = $subheader;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHeaderLink()
+    {
+        return $this->headerLink;
+    }
+
+    /**
+     * @param $headerLink
+     */
+    public function setHeaderLink($headerLink)
+    {
+        $this->headerLink = $headerLink;
+    }
+
+    /**
+     * @return string
+     */
+    public function getImageLink()
+    {
+        return $this->imageLink;
+    }
+
+    /**
+     * @param $imageLink
+     */
+    public function setImageLink($imageLink)
+    {
+        $this->imageLink = $imageLink;
+    }
+
+    /**
+     * @return string
+     */
+    public function getImageZoom()
+    {
+        return $this->imageZoom;
+    }
+
+    /**
+     * @param $imageZoom
+     */
+    public function setImageZoom($imageZoom)
+    {
+        $this->imageZoom = $imageZoom;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAltText()
+    {
+        return $this->altText;
+    }
+
+    /**
+     * @param $altText
+     */
+    public function setAltText($altText)
+    {
+        $this->altText = $altText;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitleText()
+    {
+        return $this->titleText;
+    }
+
+    /**
+     * @param $titleText
+     */
+    public function setTitleText($titleText)
+    {
+        $this->titleText = $titleText;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHeaderLayout()
+    {
+        return $this->headerLayout;
+    }
+
+    /**
+     * @param $headerLayout
+     */
+    public function setHeaderLayout($headerLayout)
+    {
+        $this->headerLayout = $headerLayout;
+    }
+
+    /**
+     * @return string
+     */
+    public function getListType()
+    {
+        return $this->listType;
+    }
+
+    /**
+     * @param $listType
+     */
+    public function setListType($listType)
+    {
+        $this->listType = $listType;
+    }
+}

--- a/Classes/ViewHelpers/MetaTagViewHelper.php
+++ b/Classes/ViewHelpers/MetaTagViewHelper.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Slub\SlubEvents\ViewHelpers;
+
+/**
+ * This file is part of the "news" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
+use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
+
+/**
+ * ViewHelper to render meta tags
+ *
+ * # Example: Basic Example: News title as og:title meta tag
+ * <code>
+ * <n:metaTag property="og:title" content="{newsItem.title}" />
+ * </code>
+ * <output>
+ * <meta property="og:title" content="TYPO3 is awesome" />
+ * </output>
+ *
+ * # Example: Force the attribute "name"
+ * <code>
+ * <n:metaTag name="keywords" content="{newsItem.keywords}" />
+ * </code>
+ * <output>
+ * <meta name="keywords" content="news 1, news 2" />
+ * </output>
+ */
+class MetaTagViewHelper extends AbstractViewHelper
+{
+    use CompileWithRenderStatic;
+
+    /**
+     * Arguments initialization
+     *
+     */
+    public function initializeArguments()
+    {
+        $this->registerArgument('property', 'string', 'Property of meta tag', false, '', false);
+        $this->registerArgument('name', 'string', 'Content of meta tag using the name attribute', false, '', false);
+        $this->registerArgument('content', 'string', 'Content of meta tag', true, null, false);
+        $this->registerArgument('useCurrentDomain', 'boolean', 'Use current domain', false, false);
+        $this->registerArgument('forceAbsoluteUrl', 'boolean', 'Force absolut domain', false, false);
+    }
+
+    public static function renderStatic(array $arguments, \Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        // Skip if current record is part of tt_content CType shortcut
+        if (!empty($GLOBALS['TSFE']->recordRegister)
+            && is_array($GLOBALS['TSFE']->recordRegister)
+            && strpos(array_keys($GLOBALS['TSFE']->recordRegister)[0], 'tt_content:') !== false
+            && !empty($GLOBALS['TSFE']->currentRecord)
+            && strpos($GLOBALS['TSFE']->currentRecord, 'tx_news_domain_model_news:') !== false
+        ) {
+            return;
+        }
+
+        $useCurrentDomain = $arguments['useCurrentDomain'];
+        $forceAbsoluteUrl = $arguments['forceAbsoluteUrl'];
+        $content = (string)$arguments['content'];
+
+        // set current domain
+        if ($useCurrentDomain) {
+            $content = GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL');
+        }
+
+        // prepend current domain
+        if ($forceAbsoluteUrl) {
+            $parsedPath = parse_url($content);
+            if (is_array($parsedPath) && !isset($parsedPath['host'])) {
+                $content =
+                    rtrim(GeneralUtility::getIndpEnv('TYPO3_SITE_URL'), '/')
+                    . '/'
+                    . ltrim($content, '/');
+            }
+        }
+
+        if ($content !== '') {
+            $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+            if ($arguments['property']) {
+                $pageRenderer->setMetaTag('property', $arguments['property'], $content);
+            } elseif ($arguments['name']) {
+                $pageRenderer->setMetaTag('property', $arguments['name'], $content);
+            }
+        }
+    }
+}

--- a/Configuration/TCA/tx_slubevents_domain_model_event.php
+++ b/Configuration/TCA/tx_slubevents_domain_model_event.php
@@ -25,7 +25,7 @@ return [
         'iconfile'                 => 'EXT:slub_events/Resources/Public/Icons/tx_slubevents_domain_model_event.gif',
     ],
     'interface' => [
-        'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, title, start_date_time, all_day, end_date_time, sub_end_date_time, teaser, description, content_elements, min_subscriber, max_subscriber, audience, sub_end_date_info_sent, no_search, genius_bar, parent, recurring, recurring_options, recurring_end_date_time, cancelled, categories, subscribers, location, discipline, contact',
+        'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, title, start_date_time, all_day, end_date_time, sub_end_date_time, teaser, description, content_elements, image, min_subscriber, max_subscriber, audience, sub_end_date_info_sent, no_search, genius_bar, parent, recurring, recurring_options, recurring_end_date_time, cancelled, categories, subscribers, location, discipline, contact',
     ],
     'types'     => [
         // Single event
@@ -40,6 +40,7 @@ return [
                 'description,' .
                 '--div--;' . $LL . 'tx_slubevents_domain_model_event.content_elements,' .
                 'content_elements,' .
+                'image,' .
                 '--div--;Anmeldebedingungen,' .
                 'contact,' .
                 'external_registration,' .
@@ -344,6 +345,27 @@ return [
                     'allowLanguageSynchronization' => true,
                 ],
             ]
+        ],
+        'image' => [
+            'exclude' => true,
+            'label'   => $LL . 'tx_slubevents_domain_model_event.image',
+            'config' => \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getFileFieldTCAConfig(
+                'image',
+                [
+                    'maxitems' => 1,
+                    'appearance' => [
+                        'createNewRelationLinkTitle' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:images.addFileReference',
+                        'fileUploadAllowed' => false
+                    ],
+                    'foreign_match_fields' => [
+                        'fieldname' => 'image',
+                        'tablenames' => 'tx_slubevents_domain_model_event',
+                        'table_local' => 'sys_file',
+                    ],
+                    'default' => 0,
+                ],
+                $GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']
+            )
         ],
         'min_subscriber'           => [
             'displayCond' => 'FIELD:external_registration:REQ:false',

--- a/Configuration/TCA/tx_slubevents_domain_model_event.php
+++ b/Configuration/TCA/tx_slubevents_domain_model_event.php
@@ -25,7 +25,7 @@ return [
         'iconfile'                 => 'EXT:slub_events/Resources/Public/Icons/tx_slubevents_domain_model_event.gif',
     ],
     'interface' => [
-        'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, title, start_date_time, all_day, end_date_time, sub_end_date_time, teaser, description, min_subscriber, max_subscriber, audience, sub_end_date_info_sent, no_search, genius_bar, parent, recurring, recurring_options, recurring_end_date_time, cancelled, categories, subscribers, location, discipline, contact',
+        'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, title, start_date_time, all_day, end_date_time, sub_end_date_time, teaser, description, content_elements, min_subscriber, max_subscriber, audience, sub_end_date_info_sent, no_search, genius_bar, parent, recurring, recurring_options, recurring_end_date_time, cancelled, categories, subscribers, location, discipline, contact',
     ],
     'types'     => [
         // Single event
@@ -38,6 +38,8 @@ return [
                 'location,' .
                 'teaser,' .
                 'description,' .
+                '--div--;' . $LL . 'tx_slubevents_domain_model_event.content_elements,' .
+                'content_elements,' .
                 '--div--;Anmeldebedingungen,' .
                 'contact,' .
                 'external_registration,' .
@@ -313,6 +315,35 @@ return [
                 ],
                 'enableRichtext' => true,
             ],
+        ],
+        'content_elements' => [
+            'exclude' => true,
+            'label' => $LL . 'tx_slubevents_domain_model_event.content_elements',
+            'config' => [
+                'type' => 'inline',
+                'allowed' => 'tt_content',
+                'foreign_table' => 'tt_content',
+                'foreign_sortby' => 'sorting',
+                'foreign_field' => 'tx_slubevents_related_content',
+                'minitems' => 0,
+                'maxitems' => 99,
+                'appearance' => [
+                    'collapseAll' => true,
+                    'expandSingle' => true,
+                    'levelLinksPosition' => 'bottom',
+                    'useSortable' => true,
+                    'showPossibleLocalizationRecords' => true,
+                    'showRemovedLocalizationRecords' => true,
+                    'showAllLocalizationLink' => true,
+                    'showSynchronizationLink' => true,
+                    'enabledControls' => [
+                        'info' => false,
+                    ]
+                ],
+                'behaviour' => [
+                    'allowLanguageSynchronization' => true,
+                ],
+            ]
         ],
         'min_subscriber'           => [
             'displayCond' => 'FIELD:external_registration:REQ:false',

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -77,6 +77,14 @@ plugin.tx_slubevents {
     }
 }
 
+# Rendering of content elements in detail view
+lib.tx_slubevents.contentElementRendering = RECORDS
+lib.tx_slubevents.contentElementRendering {
+	tables = tt_content
+	source.current = 1
+	dontCheckPid = 1
+}
+
 module.tx_slubevents < plugin.tx_slubevents
 module.tx_slubevents {
 #    view {

--- a/Resources/Private/Language/de.locallang_csh_tx_slubevents_domain_model_event.xlf
+++ b/Resources/Private/Language/de.locallang_csh_tx_slubevents_domain_model_event.xlf
@@ -67,7 +67,7 @@
 		</trans-unit>
 		<trans-unit id="recurring.description" approved="yes" xml:space="preserve">
 			<source>Is this a recurring event? On activating this option you configure the recurring interval and create child events.</source>
-			<target>Ist dies eine Termin-Serie? 
+			<target>Ist dies eine Termin-Serie?
 Mit Aktivierung dieser Option können Sie die Wiederholungseinstellungen bearbeiten und legen die Einzelveranstaltungen der Serie an.</target>
 		</trans-unit>
 		<trans-unit id="recurring_end_date_time.description" approved="yes">
@@ -109,6 +109,10 @@ Mit Aktivierung dieser Option können Sie die Wiederholungseinstellungen bearbei
 		<trans-unit id="title.description" approved="yes">
 			<source>Title</source>
 			<target>Titel der Veranstaltung</target>
+		</trans-unit>
+		<trans-unit id="image.description" xml:space="preserve">
+			<source>Image to be used in social media sharing</source>
+			<target>Bild zur Verwendung beim Teilen in Social Media</target>
 		</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -149,6 +149,10 @@
 				<source><![CDATA[Knowledge Bar]]></source>
 				<target><![CDATA[Wissensbar-Veranstaltung]]></target>
 			</trans-unit>
+			<trans-unit id="tx_slubevents_domain_model_event.image" approved="yes">
+				<source><![CDATA[Event Image]]></source>
+				<target><![CDATA[Veranstaltungs-Bild]]></target>
+			</trans-unit>
 			<trans-unit id="tx_slubevents_domain_model_event.location" approved="yes">
 				<source><![CDATA[Location]]></source>
 				<target><![CDATA[Ort]]></target>

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -105,6 +105,10 @@
 				<source><![CDATA[Categories]]></source>
 				<target><![CDATA[Kategorie]]></target>
 			</trans-unit>
+			<trans-unit id="tx_slubevents_domain_model_event.content_elements" approved="yes">
+				<source><![CDATA[Content Elements]]></source>
+				<target><![CDATA[Inhaltselemente]]></target>
+			</trans-unit>
 			<trans-unit id="tx_slubevents_domain_model_event.contact" approved="yes">
 				<source><![CDATA[Contact]]></source>
 				<target><![CDATA[Ansprechpartner]]></target>

--- a/Resources/Private/Language/locallang_csh_tx_slubevents_domain_model_event.xlf
+++ b/Resources/Private/Language/locallang_csh_tx_slubevents_domain_model_event.xlf
@@ -74,14 +74,17 @@
 		<trans-unit id="title.description" xml:space="preserve">
 			<source>Title</source>
 		</trans-unit>
-    <trans-unit id="recurring.description" xml:space="preserve">
+		<trans-unit id="recurring.description" xml:space="preserve">
 			<source>Is this a recurring event? On activating this option you configure the recurring interval and create child events.</source>
 		</trans-unit>
-    <trans-unit id="recurring_options.description" xml:space="preserve">
+		<trans-unit id="recurring_options.description" xml:space="preserve">
 			<source>This event get's cloned multiple times depending on the recurring settings below.</source>
 		</trans-unit>
-    <trans-unit id="recurring_end_date_time.description" xml:space="preserve">
+		<trans-unit id="recurring_end_date_time.description" xml:space="preserve">
 			<source>The recurring ends on the given date.</source>
+		</trans-unit>
+		<trans-unit id="image.description" xml:space="preserve">
+			<source>Image to be used in social media sharing</source>
 		</trans-unit>
 		</body>
 	</file>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -80,6 +80,9 @@
 		<trans-unit id="tx_slubevents_domain_model_event.categories">
 			<source>Categories</source>
 		</trans-unit>
+		<trans-unit id="tx_slubevents_domain_model_event.content_elements">
+			<source>Contente Elements</source>
+		</trans-unit>
 		<trans-unit id="tx_slubevents_domain_model_event.contact">
 			<source>Contact</source>
 		</trans-unit>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -107,16 +107,19 @@
 		<trans-unit id="tx_slubevents_domain_model_event.external_registration">
 			<source>External Registration Link</source>
 		</trans-unit>
+		<trans-unit id="tx_slubevents_domain_model_event.image">
+			<source>Event Image</source>
+		</trans-unit>
 		<trans-unit id="tx_slubevents_domain_model_event.genius_bar">
 			<source>Knowledge Bar</source>
 		</trans-unit>
-    <trans-unit id="tx_slubevents_domain_model_event.parent">
+		<trans-unit id="tx_slubevents_domain_model_event.parent">
 			<source>Parent Event</source>
 		</trans-unit>
-    <trans-unit id="tx_slubevents_domain_model_event.recurring">
+		<trans-unit id="tx_slubevents_domain_model_event.recurring">
 			<source>Recurring Event</source>
 		</trans-unit>
-    <trans-unit id="tx_slubevents_domain_model_event.recurring_events">
+		<trans-unit id="tx_slubevents_domain_model_event.recurring_events">
 			<source>Recurring Events</source>
 		</trans-unit>
 		<trans-unit id="tx_slubevents_domain_model_event.recurring_options">

--- a/Resources/Private/Partials/Event/Opengraph.html
+++ b/Resources/Private/Partials/Event/Opengraph.html
@@ -1,0 +1,22 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+	  xmlns:se="http://typo3.org/ns/Slub/SlubEvents/ViewHelpers"
+	  data-namespace-typo3-fluid="true">
+
+<se:metaTag property="og:url" content="" useCurrentDomain="1" />
+<f:if condition="{event.image}">
+    <se:metaTag
+        property="og:image"
+        content="{f:uri.image(image:'{event.image}', maxWidth:'1200')}"
+        forceAbsoluteUrl="1" />
+</f:if>
+<f:if condition="{event.description}">
+	<f:then>
+		<se:metaTag name="description" content="{event.description}" />
+		<se:metaTag property="og:description" content="{event.description}" />
+	</f:then>
+	<f:else>
+		<se:metaTag name="description" content="{event.teaser -> f:format.stripTags()}" />
+		<se:metaTag property="og:description" content="{event.teaser -> f:format.stripTags()}" />
+	</f:else>
+</f:if>
+</html>

--- a/Resources/Private/Templates/Event/Show.html
+++ b/Resources/Private/Templates/Event/Show.html
@@ -14,6 +14,11 @@
 
 				<f:format.html>{event.description}</f:format.html>
 
+				<f:if condition="{event.contentElements}">
+					<!-- content elements -->
+					<f:cObject typoscriptObjectPath="lib.tx_slubevents.contentElementRendering">{event.contentElementIdList}</f:cObject>
+				</f:if>
+
 				<f:if condition="{event.contact.photo}">
 					<f:then>
 						<div class="single-contact">

--- a/Resources/Private/Templates/Event/Show.html
+++ b/Resources/Private/Templates/Event/Show.html
@@ -6,7 +6,9 @@
 	<div class="slub-event-show">
 		<f:if condition="{event}">
 			<f:then>
-				<h3>{event.title}</h3>
+                <f:render partial="Event/Opengraph" arguments="{event: event, settings:settings}" />
+
+                <h3>{event.title}</h3>
 				<strong><f:spaceless><f:render partial="Event/DateFromTo" arguments="{event : event}" /></f:spaceless></strong>,
 				<f:spaceless>
 					<f:render partial="Location/Link" arguments="{location: event.location, doLink: 'false', onlyParent: 'true'}" />

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -14,6 +14,7 @@ CREATE TABLE tx_slubevents_domain_model_event (
     sub_end_date_time int(11) DEFAULT '0' NOT NULL,
     teaser text NOT NULL,
     description text NOT NULL,
+	content_elements int(11) DEFAULT '0' NOT NULL,
     min_subscriber int(11) DEFAULT '0' NOT NULL,
     max_subscriber int(11) DEFAULT '0' NOT NULL,
     max_number int(11) DEFAULT '0' NOT NULL,
@@ -301,4 +302,12 @@ CREATE TABLE tx_slubevents_event_discipline_mm (
 
     KEY uid_local (uid_local),
     KEY uid_foreign (uid_foreign)
+);
+
+#
+# Table structure for table 'tt_content'
+#
+CREATE TABLE tt_content (
+	tx_slubevents_related_content int(11) DEFAULT '0' NOT NULL,
+	KEY index_eventscontent (tx_slubevents_related_content)
 );

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -14,6 +14,7 @@ CREATE TABLE tx_slubevents_domain_model_event (
     sub_end_date_time int(11) DEFAULT '0' NOT NULL,
     teaser text NOT NULL,
     description text NOT NULL,
+	image int(11) unsigned DEFAULT '0',
 	content_elements int(11) DEFAULT '0' NOT NULL,
     min_subscriber int(11) DEFAULT '0' NOT NULL,
     max_subscriber int(11) DEFAULT '0' NOT NULL,

--- a/ext_typoscript_setup.txt
+++ b/ext_typoscript_setup.txt
@@ -1,0 +1,18 @@
+
+# ==============================================
+# Persistence object mapping configuration
+# ==============================================
+config.tx_extbase.persistence.classes {
+
+	Slub\SlubEvents\Domain\Model\TtContent {
+		mapping {
+			tableName = tt_content
+			columns {
+				altText.mapOnProperty = altText
+				titleText.mapOnProperty = titleText
+				colPos.mapOnProperty = colPos
+				CType.mapOnProperty = CType
+			}
+		}
+	}
+}


### PR DESCRIPTION
This solution is taken from the news extension. It is still missing the possibility to set the `og:image` open graph tag.

This would implement #83.