### PR TITLE
Print description in raw format to keep valid link encoding

### DIFF
--- a/Resources/Private/Templates/Event/PrintCal.ics
+++ b/Resources/Private/Templates/Event/PrintCal.ics
@@ -20,8 +20,8 @@ TZOFFSETTO:+0100
 END:STANDARD
 END:VTIMEZONE
 BEGIN:VEVENT
-ORGANIZER;CN="{event.contact.0.name}":MAILTO:{event.contact.0.email}
-DESCRIPTION:{helper.description}
+ORGANIZER;CN="{event.contact.name}":MAILTO:{event.contact.email}
+DESCRIPTION:<f:format.raw>{helper.description}</f:format.raw>
 SUMMARY:{event.title}
 UID:{event.uid}-event-dav-ke
 <f:if condition="{helper.allDay} == 1"><f:then>


### PR DESCRIPTION
But or not - that's the question.

The HTML markup of the description field (should be the teaser fiel in future?) is converted to plain text. Links are not kept. But if a hyperlink is inside the text, it is printed into the ICS file.

As we cleaned up the HTML code before, it should be safe to use the format.raw viewhelper at this point.