### PR TITLE
Fix empty unsubscribePid

### DIFF
--- a/Classes/Service/EventService.php
+++ b/Classes/Service/EventService.php
@@ -55,7 +55,7 @@ class EventService
         return $this->subscriberService->addUnsubscribeUrl(
             $user,
             $events,
-            $settings['unsubscribePid']
+            (int)$settings['unsubscribePid']
         );
     }
 }

--- a/Classes/Service/SubscriberService.php
+++ b/Classes/Service/SubscriberService.php
@@ -56,6 +56,10 @@ class SubscriberService
      */
     public function addUnsubscribeUrl(int $user, array $events, int $unsubscribePid): array
     {
+        if ($unsubscribePid === 0) {
+            return $events;
+        }
+
         $preparedEvents = [];
         $unsubscribeUrl = $this->getUnsubscribeUrl($unsubscribePid);
 
@@ -67,7 +71,7 @@ class SubscriberService
                 continue;
             }
 
-            $event->setUnsubscribeUrl($unsubscribeUrl . '&' . $preparedUnsubscribeParameter);
+            $event->setUnsubscribeUrl($unsubscribeUrl . $preparedUnsubscribeParameter);
 
             $preparedEvents[] = $event;
         }

--- a/Documentation/Api/Index.rst
+++ b/Documentation/Api/Index.rst
@@ -43,6 +43,14 @@ tx_slubevents_apieventlist[limit]             Integer              Limit quantit
 If you use these parameter and have trouble add "tx_slubevents_apieventlist" in [FE][cacheHash][cachedParametersWhiteList] and
 [FE][cacheHash][excludedParameters].
 
+Typoscript constants
+^^^^^^^^^^^^^^^^^^^^
+
+============================================= ==================== ================================================
+Parameter                                     Type                 Comment
+============================================= ==================== ================================================
+settings.unsubscribePid                       Integer              Set the page to unsubscribe an event. If not set, link to unsibscribe not generated
+
 Event list user
 ---------------
 

--- a/Documentation/Api/Index.rst
+++ b/Documentation/Api/Index.rst
@@ -49,7 +49,8 @@ Typoscript constants
 ============================================= ==================== ================================================
 Parameter                                     Type                 Comment
 ============================================= ==================== ================================================
-settings.unsubscribePid                       Integer              Set the page to unsubscribe an event. If not set, link to unsibscribe not generated
+settings.unsubscribePid                       Integer              Set the page to unsubscribe an event. If not set, link to unsubscribe not generated
+============================================= ==================== ================================================
 
 Event list user
 ---------------


### PR DESCRIPTION
If typoscript unsubscribePid is empty the api fails. That is fixed and shows no unsubscribe link, when this is empty.