### PR TITLE
Add 'hide cancelled events' button

### DIFF
--- a/Classes/Domain/Repository/EventRepository.php
+++ b/Classes/Domain/Repository/EventRepository.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Slub\SlubEvents\Domain\Repository;
 
 /***************************************************************
@@ -225,6 +226,11 @@ class EventRepository extends Repository
         if (!empty($settings['startTimestamp']) && !empty($settings['stopTimestamp'])) {
             $constraints[] = $query->greaterThanOrEqual('start_date_time', $settings['startTimestamp']);
             $constraints[] = $query->lessThanOrEqual('start_date_time', $settings['stopTimestamp']);
+        }
+
+        // Hide events that are cancelled (default is 'show cancelled events')
+        if ($settings['hideCancelledEvents']) {
+            $constraints[] = $query->equals('cancelled', '0');
         }
 
         // AND all constraints together
@@ -495,7 +501,6 @@ class EventRepository extends Repository
         }
 
         return $query->execute()->getFirst();
-
     }
 
     /**
@@ -533,10 +538,9 @@ class EventRepository extends Repository
 
         $eventsToBeRemoved = $query->execute();
 
-        foreach($eventsToBeRemoved as $eventRemove) {
+        foreach ($eventsToBeRemoved as $eventRemove) {
             $this->remove($eventRemove);
         }
-
     }
 
     /**
@@ -569,12 +573,13 @@ class EventRepository extends Repository
     }
 
     /**
-	 * Find all events older than given days
-	 *
-	 * @param integer $days
-	 * @return objects found old events
-	 */
-	public function findOlderThan($days) {
+     * Find all events older than given days
+     *
+     * @param integer $days
+     * @return objects found old events
+     */
+    public function findOlderThan($days)
+    {
 
         $query = $this->createQuery();
         $query->getQuerySettings()->setIgnoreEnableFields(true);
@@ -589,7 +594,6 @@ class EventRepository extends Repository
         }
 
         return $query->execute();
-
     }
 
     /**

--- a/Configuration/FlexForms/flexform_eventlist.xml
+++ b/Configuration/FlexForms/flexform_eventlist.xml
@@ -128,6 +128,17 @@
                         </TCEforms>
                     </settings.showPastEvents>
 
+                    <settings.hideCancelledEvents>
+                        <TCEforms>
+                            <label>LLL:EXT:slub_events/Resources/Private/Language/locallang_be.xlf:flexforms.hide_cancelled_events</label>
+                            <displayCond>FIELD:switchableControllerActions:!=:Event->show;Event->showNotFound</displayCond>
+                            <config>
+                                <type>check</type>
+                                <default>0</default>
+                            </config>
+                        </TCEforms>
+                    </settings.hideCancelledEvents>
+
                     <settings.showEventsFromNow>
                         <TCEforms>
                             <label>LLL:EXT:slub_events/Resources/Private/Language/locallang_be.xlf:flexforms.show_events_from_now</label>

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -138,6 +138,10 @@
 				<source><![CDATA[Show Past Events]]></source>
 				<target><![CDATA[Zeige vergangene Veranstaltungen]]></target>
 			</trans-unit>
+			<trans-unit id="flexforms.hide_cancelled_events">
+				<source><![CDATA[Hide Cancelled Events]]></source>
+				<target><![CDATA[Verstecke abgesagte Events]]></target>
+			</trans-unit>
 			<trans-unit id="flexforms.showconsultations" approved="yes">
 				<source><![CDATA[Show consultations]]></source>
 				<target><![CDATA[Sprechstunden anzeigen]]></target>

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -140,7 +140,7 @@
 			</trans-unit>
 			<trans-unit id="flexforms.hide_cancelled_events">
 				<source><![CDATA[Hide Cancelled Events]]></source>
-				<target><![CDATA[Verstecke abgesagte Events]]></target>
+				<target><![CDATA[Abgesagte Events ausblenden]]></target>
 			</trans-unit>
 			<trans-unit id="flexforms.showconsultations" approved="yes">
 				<source><![CDATA[Show consultations]]></source>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -90,6 +90,9 @@
 		<trans-unit id="flexforms.show_past_events">
 			<source>Show Past Events</source>
 		</trans-unit>
+		<trans-unit id="flexforms.hide_cancelled_events">
+			<source>Hide Cancelled Events</source>
+		</trans-unit>
 		<trans-unit id="flexforms.show_events_from_now">
 			<source>Show Events from Now and Not from Start of Today</source>
 		</trans-unit>


### PR DESCRIPTION
This PR brings a new function to the event list views. In the backend there is now an new button that 's hide all cancelled events in the list. It'll add a request to the database query which only get rows where cancelled is NULL. 