### PR TITLE
Change customerid from number to text

### DIFF
--- a/Classes/Domain/Validator/SubscriberValidator.php
+++ b/Classes/Domain/Validator/SubscriberValidator.php
@@ -103,12 +103,6 @@ class SubscriberValidator extends AbstractValidator
 			$this->addError('val_email', 1100);
             $this->isValid = false;
         }
-        if (strlen($newSubscriber->getCustomerid()) > 0 &&
-            filter_var($newSubscriber->getCustomerid(), FILTER_VALIDATE_INT) === false
-        ) {
-			$this->addError('val_customerid', 1110);
-            $this->isValid = false;
-        }
         if (strlen($newSubscriber->getNumber()) == 0 ||
             filter_var($newSubscriber->getNumber(), FILTER_VALIDATE_INT) === false ||
             $newSubscriber->getNumber() < 1

--- a/Resources/Private/Partials/Subscriber/FormFields.html
+++ b/Resources/Private/Partials/Subscriber/FormFields.html
@@ -14,7 +14,7 @@
 <label for="customerid">
 	<f:translate key="tx_slubevents_domain_model_subscriber.customerid"/>
 </label>
-<f:form.textfield id="customerid" type="number" additionalAttributes="{min: '1', max: '9999999'}" readonly="{readonly}"
+<f:form.textfield id="customerid" type="text" readonly="{readonly}"
 				  property="customerid"/><br/>
 
 <label for="number">


### PR DESCRIPTION
This PR changes the definition of the field customerid from number to text inside the subscription form. There is no underlying need to restrict the userid to numerical values. The validators is changed as well, otherwise there would be a validation error.