### PR TITLE
[feature] Allow to hide fully book events in listings

### DIFF
--- a/Configuration/FlexForms/flexform_eventlist.xml
+++ b/Configuration/FlexForms/flexform_eventlist.xml
@@ -140,6 +140,17 @@
                         </TCEforms>
                     </settings.hideCancelledEvents>
 
+                    <settings.hideFullyBookedEvents>
+                        <TCEforms>
+                            <label>LLL:EXT:slub_events/Resources/Private/Language/locallang_be.xlf:flexforms.hide_fully_booked_events</label>
+                            <displayCond>FIELD:switchableControllerActions:!=:Event->show;Event->showNotFound</displayCond>
+                            <config>
+                                <type>check</type>
+                                <default>0</default>
+                            </config>
+                        </TCEforms>
+                    </settings.hideFullyBookedEvents>
+
                     <settings.showEventsFromNow>
                         <TCEforms>
                             <label>LLL:EXT:slub_events/Resources/Private/Language/locallang_be.xlf:flexforms.show_events_from_now</label>

--- a/Resources/Private/Language/de.locallang_be.xlf
+++ b/Resources/Private/Language/de.locallang_be.xlf
@@ -138,9 +138,13 @@
 				<source><![CDATA[Show Past Events]]></source>
 				<target><![CDATA[Zeige vergangene Veranstaltungen]]></target>
 			</trans-unit>
-			<trans-unit id="flexforms.hide_cancelled_events">
+			<trans-unit id="flexforms.hide_cancelled_events" approved="yes">
 				<source><![CDATA[Hide Cancelled Events]]></source>
 				<target><![CDATA[Abgesagte Events ausblenden]]></target>
+			</trans-unit>
+			<trans-unit id="flexforms.hide_fully_booked_events" approved="yes">
+				<source>Hide fully booked events</source>
+				<target>Ausgebuchte Veranstaltungen ausblenden</target>
 			</trans-unit>
 			<trans-unit id="flexforms.showconsultations" approved="yes">
 				<source><![CDATA[Show consultations]]></source>

--- a/Resources/Private/Language/locallang_be.xlf
+++ b/Resources/Private/Language/locallang_be.xlf
@@ -93,6 +93,9 @@
 		<trans-unit id="flexforms.hide_cancelled_events">
 			<source>Hide Cancelled Events</source>
 		</trans-unit>
+		<trans-unit id="flexforms.hide_fully_booked_events">
+			<source>Hide fully booked events</source>
+		</trans-unit>
 		<trans-unit id="flexforms.show_events_from_now">
 			<source>Show Events from Now and Not from Start of Today</source>
 		</trans-unit>


### PR DESCRIPTION
Adds a new plugin setting that defines whether or not fully booked events should be listed (default behavior: show fully booked events). A corresponding flexform element is provided as well.